### PR TITLE
Changed hibernate core for spring starter data jpa and correct PriceEntity

### DIFF
--- a/prices/pom.xml
+++ b/prices/pom.xml
@@ -36,6 +36,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<scope>runtime</scope>
@@ -51,12 +56,6 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.hibernate.orm</groupId>
-			<artifactId>hibernate-core</artifactId>
-			<version>6.6.13.Final</version>
 		</dependency>
 
 	</dependencies>

--- a/prices/src/main/java/com/inditex/core/prices/infrastructure/db/dto/PriceEntity.java
+++ b/prices/src/main/java/com/inditex/core/prices/infrastructure/db/dto/PriceEntity.java
@@ -3,29 +3,33 @@ package com.inditex.core.prices.infrastructure.db.dto;
 import java.time.Instant;
 import java.util.Currency;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import lombok.Getter;
 
 @Entity
 @Getter
-@Table(name = "prices")
+@Table(name = "PRICES")
 public class PriceEntity {
 
-    private String brandId;
+    @EmbeddedId
+    private PriceId priceId;
 
+    @Column(name = "START_DATE")
     private Instant startDate;
 
+    @Column(name = "END_DATE")
     private Instant endDate;
 
-    private int priceList;
-
-    private long productId;
-
+    @Column(name = "PRIORITY")
     private int priority;
 
+    @Column(name = "PRICE")
     private float price;
 
-    private Currency currency;
+    @Column(name = "CURR")
+    private Currency curr;
     
 }

--- a/prices/src/main/java/com/inditex/core/prices/infrastructure/db/dto/PriceId.java
+++ b/prices/src/main/java/com/inditex/core/prices/infrastructure/db/dto/PriceId.java
@@ -1,0 +1,26 @@
+package com.inditex.core.prices.infrastructure.db.dto;
+
+import java.io.Serializable;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Embeddable
+@AllArgsConstructor
+@Getter
+public class PriceId implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Column(name = "BRAND_ID")
+    private String brandId;
+
+    @Column(name = "PRODUCT_ID")
+    private Long productId;
+
+    @Column(name = "PRICE_LIST")
+    private Integer priceList;
+
+} 


### PR DESCRIPTION
Changed Hibernate library to spring' starter data jpa library just to simplify and not forget any dependency.
It required to adjust PriceEntity that had not an id, using an embedded id.